### PR TITLE
Feature/best practices from metabuildbot

### DIFF
--- a/master.cfg
+++ b/master.cfg
@@ -108,21 +108,23 @@ def create_builder(repo_name):
     factory = BuildFactory()
 
     remove_virtualenv = ["rm", "-rf", venv_name]
-    virtualenv_command = ["virtualenv", "--python=python2", venv_name]
-    update_setuptools_command = "pip install -U pip setuptools"
-    install_pep8 = "pip install --upgrade pep8"
+    create_virtualenv = ["virtualenv", "--python=python2", venv_name]
+    update_setuptools = ['pip', 'install', '-U', 'pip', 'setuptools']
+    install_pep8 = ['pip', 'install', '--upgrade', 'pep8']
+    sandbox_path = {'PATH':  "./" + venv_name + '/bin' + ':${PATH}'}
+    sandbox_path_factory = {'PATH':  "../" + venv_name + '/bin' + ':${PATH}'}
 
     repo_index = [repo[order_repos_index] for repo in REPOS if repo[0] is repo_name][0]
 
     factory.addStep(ShellCommand(command=remove_virtualenv, haltOnFailure=True, workdir=".", name = "Remove previous virtualenv"))
-    factory.addStep(ShellCommand(command=virtualenv_command, haltOnFailure=True, workdir=".", name = "Create new virtualenv"))
-    factory.addStep(ShellCommand(command=["bash", "-c", "source " + venv_name + "/bin/activate" + " && " + update_setuptools_command], workdir=".", name = "Update setuptools"))
-    factory.addStep(ShellCommand(command=["bash", "-c", "source " + venv_name + "/bin/activate" + " && " + install_pep8], workdir=".", name = "Install pep8"))
+    factory.addStep(ShellCommand(command=create_virtualenv, haltOnFailure=True, workdir=".", name = "Create new virtualenv"))
+    factory.addStep(ShellCommand(command=update_setuptools, env=sandbox_path, workdir=".", name = "Update setuptools"))
+    factory.addStep(ShellCommand(command=install_pep8, env=sandbox_path, workdir=".", name = "Install pep8"))
     for repo_name, repo_branch, repo_url, _, namespace, in sorted(REPOS, key = lambda repo: repo[order_repos_index])[0:repo_index]:
         add_repo_to_factory(factory, repo_name, repo_url, namespace, venv_name)
 
     if namespace is not '':
-        factory.addStep(ShellCommand(command=["bash", "-c", "source ../" + venv_name + "/bin/activate" + " && " + "trial " + namespace], name = "trial " + namespace, workdir="workdir-" + repo_name))
+        factory.addStep(ShellCommand(command=['trial', namespace], env=sandbox_path_factory, name = "trial " + namespace, workdir="workdir-" + repo_name))
 
     return BuilderConfig(name=builder_name, slavenames=[slave_name], factory=factory)
 

--- a/master.cfg
+++ b/master.cfg
@@ -94,37 +94,38 @@ def add_repo_to_factory(factory, repo_name, repo_url, namespace, venv_name):
     ])
     if 'soledad.git' in repo_url:
         for subpackage in ["common", "client", "server"]:
-            factory.addStep(ShellCommand(command=install_requirements, env=sandbox_path_soledad, haltOnFailure=True, workdir=workdir+'/'+subpackage, name="reqs: " + repo_name+"."+subpackage))
-            factory.addStep(ShellCommand(command=install_requirements_tests, env=sandbox_path_soledad, haltOnFailure=True, workdir=workdir+'/'+subpackage, name="test reqs: " + repo_name+"."+subpackage))
-            factory.addStep(ShellCommand(command=install, env=sandbox_path_soledad, haltOnFailure=True, workdir=workdir+'/'+subpackage, name="Install " + repo_name+"."+subpackage))
+            factory.addSteps([
+                ShellCommand(command=install_requirements, env=sandbox_path_soledad, haltOnFailure=True, workdir=workdir+'/'+subpackage, name="reqs: " + repo_name+"."+subpackage),
+                ShellCommand(command=install_requirements_tests, env=sandbox_path_soledad, haltOnFailure=True, workdir=workdir+'/'+subpackage, name="test reqs: " + repo_name+"."+subpackage),
+                ShellCommand(command=install, env=sandbox_path_soledad, haltOnFailure=True, workdir=workdir+'/'+subpackage, name="Install " + repo_name+"."+subpackage)
+            ])
     else:
-        factory.addStep(ShellCommand(command=install_requirements, env=sandbox_path, haltOnFailure=False, workdir=workdir, name="reqs: " + repo_name))
-        factory.addStep(ShellCommand(command=install_requirements_tests, env=sandbox_path, haltOnFailure=False, workdir=workdir, name="test reqs: " + repo_name))
-        factory.addStep(ShellCommand(command=install, env=sandbox_path, haltOnFailure=True, workdir=workdir, name="Install " + repo_name))
+        factory.addSteps([
+            ShellCommand(command=install_requirements, env=sandbox_path, haltOnFailure=False, workdir=workdir, name="reqs: " + repo_name),
+            ShellCommand(command=install_requirements_tests, env=sandbox_path, haltOnFailure=False, workdir=workdir, name="test reqs: " + repo_name),
+            ShellCommand(command=install, env=sandbox_path, haltOnFailure=True, workdir=workdir, name="Install " + repo_name)
+        ])
 
 def create_builder(repo_name):
     builder_name = 'builder_' + repo_name
     venv_name = "virtualenv_ci_" + builder_name
-    factory = BuildFactory()
+    venv_path = {'PATH':  "./" + venv_name + '/bin' + ':${PATH}'}
+    venv_path_factory = {'PATH':  "../" + venv_name + '/bin' + ':${PATH}'}
 
-    remove_virtualenv = ["rm", "-rf", venv_name]
-    create_virtualenv = ["virtualenv", "--python=python2", venv_name]
-    update_setuptools = ['pip', 'install', '-U', 'pip', 'setuptools']
-    install_pep8 = ['pip', 'install', '--upgrade', 'pep8']
-    sandbox_path = {'PATH':  "./" + venv_name + '/bin' + ':${PATH}'}
-    sandbox_path_factory = {'PATH':  "../" + venv_name + '/bin' + ':${PATH}'}
+    factory = BuildFactory()
+    factory.addSteps([
+        ShellCommand(command=["rm", "-rf", venv_name], haltOnFailure=True, workdir=".", name="Remove previous virtualenv"),
+        ShellCommand(command=["virtualenv", "--python=python2", venv_name], haltOnFailure=True, workdir=".", name="Create new virtualenv"),
+        ShellCommand(command=['pip', 'install', '-U', 'pip', 'setuptools'], env=venv_path, workdir=".", name="Update setuptools"),
+        ShellCommand(command=['pip', 'install', '--upgrade', 'pep8'], env=venv_path, workdir=".", name="Install pep8")
+    ])
 
     repo_index = [repo[order_repos_index] for repo in REPOS if repo[0] is repo_name][0]
-
-    factory.addStep(ShellCommand(command=remove_virtualenv, haltOnFailure=True, workdir=".", name = "Remove previous virtualenv"))
-    factory.addStep(ShellCommand(command=create_virtualenv, haltOnFailure=True, workdir=".", name = "Create new virtualenv"))
-    factory.addStep(ShellCommand(command=update_setuptools, env=sandbox_path, workdir=".", name = "Update setuptools"))
-    factory.addStep(ShellCommand(command=install_pep8, env=sandbox_path, workdir=".", name = "Install pep8"))
     for repo_name, repo_branch, repo_url, _, namespace, in sorted(REPOS, key = lambda repo: repo[order_repos_index])[0:repo_index]:
         add_repo_to_factory(factory, repo_name, repo_url, namespace, venv_name)
 
     if namespace is not '':
-        factory.addStep(ShellCommand(command=['trial', namespace], env=sandbox_path_factory, name = "trial " + namespace, workdir="workdir-" + repo_name))
+        factory.addStep(ShellCommand(command=['trial', namespace], env=venv_path_factory, workdir="workdir-" + repo_name, name="trial "+namespace))
 
     return BuilderConfig(name=builder_name, slavenames=[slave_name], factory=factory)
 

--- a/master.cfg
+++ b/master.cfg
@@ -78,42 +78,29 @@ from buildbot.process.factory import BuildFactory
 from buildbot.steps.source.git import Git
 from buildbot.steps.shell import ShellCommand
 from buildbot.config import BuilderConfig
-from buildbot import locks
 
 def add_repo_to_factory(factory, repo_name, repo_url, namespace, venv_name):
     install_requirements = 'pkg/pip_install_requirements.sh'
     install_requirements_tests = "if [ -f pkg/requirements-testing.pip ]; then pip install --upgrade -r pkg/requirements-testing.pip; fi"
-    setup_py_install = "python setup.py develop"
+    install = "python setup.py develop"
 
-    sandboxed_setup_install_soledad = ["bash", "-c", "source ../../" + venv_name + "/bin/activate" + " && " + setup_py_install]
-    sandboxed_setup_install_requirements_soledad = ["bash", "-c", "source ../../" + venv_name + "/bin/activate" + " && " + install_requirements]
-    sandboxed_setup_install_requirements_tests_soledad = ["bash", "-c", "source ../../" + venv_name + "/bin/activate" + " && " + install_requirements_tests]
-    sandboxed_setup_install = ["bash", "-c", "source ../" + venv_name + "/bin/activate" + " && " + setup_py_install]
-    sandboxed_setup_install_requirements = ["bash", "-c", "source ../" + venv_name + "/bin/activate" + " && " + install_requirements]
-    sandboxed_setup_install_requirements_tests = ["bash", "-c", "source ../" + venv_name + "/bin/activate" + " && " + install_requirements_tests]
-    sandboxed_pep8 = ["bash", "-c", "source ../" + venv_name + "/bin/activate" + " && " + "pep8 ."]
     workdir = "workdir-" + repo_name
-    
+    sandbox_path = {'PATH':  "../" + venv_name + '/bin/' + ':${PATH}'}
+    sandbox_path_soledad = {'PATH':  "../../" + venv_name + '/bin/' + ':${PATH}'}
+
     factory.addSteps([
         Git(repourl=repo_url, workdir=workdir, mode='incremental', method='clean', haltOnFailure=True, name="Pull " + repo_url),
-        ShellCommand(command=sandboxed_pep8, haltOnFailure=False, workdir=workdir, name="pep8 on " + repo_name)
+        ShellCommand(command=['pep8', '.'],env=sandbox_path,haltOnFailure=False, workdir=workdir, name="pep8 on " + repo_name)
     ])
     if 'soledad.git' in repo_url:
-        factory.addStep(ShellCommand(command=sandboxed_setup_install_requirements_soledad, haltOnFailure=True, workdir=workdir + "/common", name="Install requirements of soledad.common"))
-        factory.addStep(ShellCommand(command=sandboxed_setup_install_requirements_tests_soledad, haltOnFailure=True, workdir=workdir + "/common", name="Install testing requirements of soledad.common"))
-        factory.addStep(ShellCommand(command=sandboxed_setup_install_soledad, haltOnFailure=True, workdir=workdir + "/common", name="Install soledad.common"))
-        
-        factory.addStep(ShellCommand(command=sandboxed_setup_install_requirements_soledad, haltOnFailure=True, workdir=workdir + "/client", name="Install requirements of soledad.client"))
-        factory.addStep(ShellCommand(command=sandboxed_setup_install_requirements_tests_soledad, haltOnFailure=True, workdir=workdir + "/client", name="Install testing requirements of soledad.common"))
-        factory.addStep(ShellCommand(command=sandboxed_setup_install_soledad, haltOnFailure=True, workdir=workdir + "/client", name="Install soledad.client"))
-        
-        factory.addStep(ShellCommand(command=sandboxed_setup_install_requirements_soledad, haltOnFailure=True, workdir=workdir + "/server", name="Install requirements of soledad.server"))
-        factory.addStep(ShellCommand(command=sandboxed_setup_install_requirements_tests_soledad, haltOnFailure=True, workdir=workdir + "/server", name="Install testing requirements of soledad.common"))
-        factory.addStep(ShellCommand(command=sandboxed_setup_install_soledad, haltOnFailure=True, workdir=workdir + "/server", name="Install soledad.server"))
+        for subpackage in ["common", "client", "server"]:
+            factory.addStep(ShellCommand(command=install_requirements, env=sandbox_path_soledad, haltOnFailure=True, workdir=workdir+'/'+subpackage, name="reqs: " + repo_name+"."+subpackage))
+            factory.addStep(ShellCommand(command=install_requirements_tests, env=sandbox_path_soledad, haltOnFailure=True, workdir=workdir+'/'+subpackage, name="test reqs: " + repo_name+"."+subpackage))
+            factory.addStep(ShellCommand(command=install, env=sandbox_path_soledad, haltOnFailure=True, workdir=workdir+'/'+subpackage, name="Install " + repo_name+"."+subpackage))
     else:
-        factory.addStep(ShellCommand(command=sandboxed_setup_install_requirements, haltOnFailure=False, workdir=workdir, name="reqs: " + repo_name))
-        factory.addStep(ShellCommand(command=sandboxed_setup_install_requirements_tests, haltOnFailure=False, workdir=workdir, name="test reqs: " + repo_name))
-        factory.addStep(ShellCommand(command=sandboxed_setup_install, haltOnFailure=True, workdir=workdir, name="Install " + repo_name))
+        factory.addStep(ShellCommand(command=install_requirements, env=sandbox_path, haltOnFailure=False, workdir=workdir, name="reqs: " + repo_name))
+        factory.addStep(ShellCommand(command=install_requirements_tests, env=sandbox_path, haltOnFailure=False, workdir=workdir, name="test reqs: " + repo_name))
+        factory.addStep(ShellCommand(command=install, env=sandbox_path, haltOnFailure=True, workdir=workdir, name="Install " + repo_name))
 
 def create_builder(repo_name):
     builder_name = 'builder_' + repo_name
@@ -139,7 +126,6 @@ def create_builder(repo_name):
 
     return BuilderConfig(name=builder_name, slavenames=[slave_name], factory=factory)
 
-exclusive_slave_lock = locks.SlaveLock("exclusive")
 c['builders'] = []
 
 for repo_name, _, _, _, _ in REPOS:


### PR DESCRIPTION
I don't use VirtualenvSetup because we need different virtualenvs for each repo, and the virtualenv overhead is minimal using the PATH technique.
