### PR TITLE
[feat] Nightly scheduler for bitmask_client and bundler

### DIFF
--- a/master.cfg
+++ b/master.cfg
@@ -65,6 +65,7 @@ def github_repo_url(repo_name):
 from buildbot.schedulers.basic import AnyBranchScheduler
 from buildbot.schedulers.forcesched import ForceScheduler
 from buildbot.changes.filter import ChangeFilter
+from buildbot.plugins import schedulers
 c['schedulers'] = []
 
 for repo_name, repo_branch, _, _ in REPOS:
@@ -84,6 +85,17 @@ c['schedulers'].append(ForceScheduler(
 c['schedulers'].append(ForceScheduler(
     name="force_build_of_bundler",
     builderNames=['builder_bundler']))
+
+c['schedulers'].append(
+    schedulers.Nightly(name='nightly_bundle',
+                       branch=None,
+                       builderNames=['builder_bundler'],
+                       hour=0, minute=0))
+c['schedulers'].append(
+    schedulers.Nightly(name='nightly_bitmask_client',
+                       branch=None,
+                       builderNames=['builder_bitmask_client'],
+                       hour=23, minute=55))
 
 ####### BUILDERS
 


### PR DESCRIPTION
Bitmask client produces the sumo tarball at 23:55 EEST, and the bundler
uses it at 00:00.
- Related: #7366
