### PR TITLE
[feat] Generate and publish coverage reports

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,6 +2,7 @@ Dependencies
 ------------
 See `Bitmask Client documentation <https://leap.se/en/docs/client/dev-environment#install-dependencies>`_
 
+- xvfb
 - qmake-qt4
 - cmake
 

--- a/master.cfg
+++ b/master.cfg
@@ -117,8 +117,8 @@ from buildbot.steps.shell import ShellCommand
 from buildbot.config import BuilderConfig
 
 def add_repo_to_factory(factory, repo_name, git_branch, namespace, venv_name):
-    install_requirements = 'pkg/pip_install_requirements.sh'
-    install_requirements_tests = "if [ -f pkg/requirements-testing.pip ]; then pkg/pip_install_requirements.sh --testing; fi"
+    install_requirements = 'pkg/pip_install_requirements.sh --use-leap-wheels'
+    install_requirements_tests = "if [ -f pkg/requirements-testing.pip ]; then pkg/pip_install_requirements.sh --testing --use-leap-wheels; fi"
     install = "python setup.py develop"
 
     workdir = repo_name
@@ -159,7 +159,7 @@ def create_builder(repo_name):
     factory.addSteps([
         ShellCommand(command=["rm", "-rf", venv_name], haltOnFailure=True, workdir=".", name="Remove previous virtualenv"),
         ShellCommand(command=["virtualenv", "--python=python2", venv_name], haltOnFailure=True, workdir=".", name="Create new virtualenv"),
-        ShellCommand(command=['pip', 'install', '-U', 'pip', 'setuptools'], env=venv_path, workdir=".", name="Update setuptools")
+        ShellCommand(command=['pip', 'install', '-U', 'pip', 'setuptools', 'coverage'], env=venv_path, workdir=".", name="Update setuptools")
     ])
 
     repo_index = [repo[order_repos_index] for repo in REPOS if repo[0] is repo_name][0]
@@ -167,12 +167,22 @@ def create_builder(repo_name):
         add_repo_to_factory(factory, repo_name, repo_branch, namespace, venv_name)
 
     factory.addSteps([
-        ShellCommand(command=['pep8', '--exclude=setup.py,versioneer.py,src._version', '--ignore=E501', '.'],env=venv_path_factory,haltOnFailure=False, workdir=repo_name, name="pep8 on " + repo_name)])
+        ShellCommand(command=['pep8', '--exclude=setup.py,versioneer.py,src._version,build', '--ignore=E501', '.'],env=venv_path_factory,haltOnFailure=False, workdir=repo_name, name="pep8 on " + repo_name)])
 
     if namespace is not '':
-        factory.addStep(ShellCommand(command=['trial', namespace], env=venv_path_factory, workdir=repo_name, name="trial "+namespace))
+        if repo_name is 'bitmask_client':
+            factory.addStep(
+                ShellCommand(command=['xvfb-run', 'coverage', 'run', '--omit=*/'+venv_name+'/*', venv_name + '/bin/trial', namespace], env=venv_path, workdir='.', name="trial "+namespace))
+        else:
+            factory.addStep(
+                ShellCommand(command=['coverage', 'run', '--omit=*/'+venv_name+'/*', venv_name + '/bin/trial', namespace], env=venv_path, workdir='.', name="trial "+namespace))
 
-    publish_leap_wheels(factory, repo_name, venv_path_factory)
+        factory.addSteps([
+            ShellCommand(command=['coverage', 'html'], env=venv_path, workdir='.', name="generate html coverage report for " +namespace),
+            ShellCommand(command=publish_coverage_reports_command('htmlcov', repo_name), workdir='.', doStepIf=(lambda step: step.getProperty('slavename') == localhost_slave))
+        ])
+
+    publish_leap_wheels(factory, repo_name, venv_path_factory, doStepIf=(lambda step: step.getProperty('slavename') == localhost_slave))
 
     if repo_name == 'bitmask_client':
         publish_sumo = publish_sumo_command('`ls -t *SUMO.tar.gz | head -1`')
@@ -191,18 +201,23 @@ def create_builder(repo_name):
 
     return BuilderConfig(name=builder_name, slavenames=[localhost_slave], factory=factory)
 
-def publish_leap_wheels(factory, repo_name, env):
+def publish_coverage_reports_command(location, repo_name):
+    target_directory = config.get('ftp', 'coverage_reports_target_directory') + '/' + repo_name + '_' + '`git -C ' + repo_name + ' describe`'
+
+    return ftp_publish_dir_command(location, target_directory)
+
+def publish_leap_wheels(factory, repo_name, env, doStepIf):
     env_soledad = {'PATH':  env['PATH'].replace('../', '../../', 1)}
 
     if repo_name == 'soledad':
         for subpackage in ["common", "client", "server"]:
             factory.addSteps([
-                ShellCommand(command=['python', 'setup.py', 'bdist_wheel'], env=env_soledad, haltOnFailure=True, workdir=repo_name+'/'+subpackage, name="leap wheels for " + repo_name+"."+subpackage),
-                ShellCommand(command=publish_leap_wheels_soledad(subpackage, '`ls -t *.whl | head -1`'), env=env_soledad, haltOnFailure=True, workdir=repo_name+'/'+subpackage+'/dist', name="publish leap wheels for " + repo_name+"."+subpackage)])
+                ShellCommand(command=['python', 'setup.py', 'bdist_wheel'], env=env_soledad, doStepIf=doStepIf, haltOnFailure=True, workdir=repo_name+'/'+subpackage, name="leap wheels for " + repo_name+"."+subpackage),
+                ShellCommand(command=publish_leap_wheels_soledad(subpackage, '`ls -t *.whl | head -1`'), env=env_soledad, doStepIf=doStepIf, haltOnFailure=True, workdir=repo_name+'/'+subpackage+'/dist', name="publish leap wheels for " + repo_name+"."+subpackage)])
     else:
         factory.addSteps([
-            ShellCommand(command=['python', 'setup.py', 'bdist_wheel'], env=env, workdir=repo_name, name="Generate leap wheels for "+repo_name),
-            ShellCommand(command=publish_leap_wheels_command(repo_name, '`ls -t *.whl | head -1`'), env=env, workdir=repo_name + '/dist', name="Publish leap wheels for "+repo_name)
+            ShellCommand(command=['python', 'setup.py', 'bdist_wheel'], env=env, doStepIf=doStepIf, workdir=repo_name, name="Generate leap wheels for "+repo_name),
+            ShellCommand(command=publish_leap_wheels_command(repo_name, '`ls -t *.whl | head -1`'), env=env, doStepIf=doStepIf, workdir=repo_name + '/dist', name="Publish leap wheels for "+repo_name)
         ])
 
 def publish_leap_wheels_command(repo_name, location):
@@ -224,6 +239,9 @@ def publish_sumo_command(location):
     return command
 
 def ftp_soft_link(filename, target_directory, symlink_name):
+    return ftp_ssh_command('ln -sf ' + target_directory + '/' + filename + ' ' + target_directory + '/' + symlink_name)
+
+def ftp_ssh_command(command):
     ssh_port = config.get('ftp', 'ssh_port')
     ssh_key = config.get('ftp', 'ssh_key')
     user = config.get('ftp', 'user')
@@ -233,7 +251,7 @@ def ftp_soft_link(filename, target_directory, symlink_name):
                    "-i", ssh_key,
                    '-p', ssh_port,
                    user + '@' + server,
-                   '"ln -sf ' + target_directory + '/' + filename + ' ' + target_directory + '/' + symlink_name + '"']
+                   '"' + command + '"']
 
     # Flatten to a string so that a shell executes de command, and
     # expands ~
@@ -248,11 +266,17 @@ def ftp_publish_command(from_location, to_location):
     user = config.get('ftp', 'user')
     server = config.get('ftp', 'server')
 
+    ssh_mkdir_command = ['ssh',
+                         "-i", ssh_key,
+                         '-p', ssh_port,
+                         user + '@' + server,
+                         '"mkdir ' + to_location + '"']
+
     scp_command = ['scp',
                    '-i', ssh_key,
                    '-P', ssh_port,
                    '-r', from_location,
-                   user + '@' + server + ':' + to_location]
+                   '"' + user + '@' + server + ':' + to_location +'"']
     ssh_command = ['ssh',
                    "-i", ssh_key,
                    '-p', ssh_port,
@@ -260,7 +284,7 @@ def ftp_publish_command(from_location, to_location):
                    '"chmod -R g+r ' + to_location + ' && chown -R ' + user + ':www-data ' + to_location + '"']
     # Flatten to a string so that a shell executes de command, and
     # expands ~
-    return ' '.join(scp_command) + ' && ' + ' '.join(ssh_command)
+    return ' '.join(ssh_mkdir_command) + ' ; ' + ' '.join(scp_command) + ' && ' + ' '.join(ssh_command)
 
 def make_wheel_builder():
     builder_name = "builder_wheels"
@@ -288,7 +312,7 @@ def make_wheel_builder():
         else:
             factory.addStep(
                 ShellCommand(command=generate_wheels, env=sandbox_path, haltOnFailure=True, workdir=workdir, name="wheels for " + repo_name))
-    factory.addStep(ShellCommand(command=publish_wheels, env=sandbox_path, haltOnFailure=True, workdir=".", name="publish wheels"))
+    factory.addStep(ShellCommand(command=publish_wheels, env=sandbox_path, doStepIf=(lambda step: step.getProperty('slavename') == localhost_slave), workdir=".", name="publish wheels"))
 
     add_pyside_setup_repo(factory)
 


### PR DESCRIPTION
Publish only the localhost_slave, and everything to the same
directory (~/coverage-reports).

The reports are generated with `coverage html`.
