### PR TITLE
[feat] Use multiple codebases

### DIFF
--- a/master.cfg
+++ b/master.cfg
@@ -49,6 +49,19 @@ REPOS=[
 def github_repo_url(repo_name):
     return 'https://github.com/' + github_repos_username + '/' + repo_name + '.git'
 
+
+all_repositories = {
+    r'https://github.com/leapcode/leap_pycommon.git': 'leap_pycommon',
+    r'https://github.com/leapcode/soledad.git': 'soledad',
+    r'https://github.com/leapcode/keymanager.git': 'keymanager',
+    r'https://github.com/leapcode/leap_mail.git': 'leap_mail',
+    r'https://github.com/leapcode/bitmask_client.git': 'bitmask_client',
+}
+def codebaseGenerator(chdict):
+    return all_repositories[chdict['repository']]
+
+c['codebaseGenerator'] = codebaseGenerator
+
 from buildbot.plugins import changes
 poll_interval_minutes = 5
 c['change_source'] = [changes.GitPoller(repourl=github_repo_url(repo_name),
@@ -62,19 +75,44 @@ c['change_source'] = [changes.GitPoller(repourl=github_repo_url(repo_name),
 # Configure the Schedulers, which decide how to react to incoming changes.
 
 from buildbot.schedulers.basic import AnyBranchScheduler
-from buildbot.schedulers.forcesched import ForceScheduler
+from buildbot.schedulers.forcesched import ForceScheduler, CodebaseParameter
 from buildbot.changes.filter import ChangeFilter
+
 from buildbot.plugins import schedulers
 c['schedulers'] = []
 
-for repo_name, repo_branch, _, _ in REPOS:
+def all_codebases(repo_name):
+    codebases = {}
+
+    repo_index = [repo[order_repos_index] for repo in REPOS if repo[0] is repo_name][0]
+    for repo_name, repo_branch, _, namespace, in sorted(REPOS, key = lambda repo: repo[order_repos_index])[0:repo_index]:
+        codebases[repo_name] = {
+            'repository' : github_repo_url(repo_name),
+            'branch' : None,
+            'revision' : None
+        }
+
+    return codebases
+
+def all_codebases_names(repo_name):
+    codebases = []
+
+    repo_index = [repo[order_repos_index] for repo in REPOS if repo[0] is repo_name][0]
+    for codebase_repo_name, codebase_repo_branch, _, _, in sorted(REPOS, key = lambda repo: repo[order_repos_index])[0:repo_index]:
+        codebases.append(CodebaseParameter(codebase=codebase_repo_name, branch=codebase_repo_branch, repository=github_repo_url(codebase_repo_name)))
+
+    return codebases
+
+for repo_name, repo_branch, order_, _ in REPOS:
     c['schedulers'].append(AnyBranchScheduler(
         name=repo_name,
-        change_filter = ChangeFilter(repository=github_repo_url(repo_name)),
+        change_filter = ChangeFilter(codebase=repo_name),
+        codebases = all_codebases(repo_name),
         builderNames=['builder_' + repo_name]))
 
     c['schedulers'].append(ForceScheduler(
         name="force_build_of_" + repo_name,
+        codebases = all_codebases_names(repo_name),
         builderNames=['builder_' + repo_name]))
 
 c['schedulers'].append(ForceScheduler(
@@ -118,7 +156,7 @@ def add_repo_to_factory(factory, repo_name, git_branch, namespace, venv_name):
     repo_url = github_repo_url(repo_name)
 
     factory.addStep(
-        Git(repourl=repo_url, branch=git_branch, workdir=workdir, mode='incremental', method='clean', haltOnFailure=True, name="Pull " + repo_url))
+        Git(repourl=repo_url, branch=git_branch, workdir=workdir, codebase=repo_name, mode='incremental', method='clean', haltOnFailure=True, name="Pull " + repo_url))
 
     if 'bitmask_client' in repo_name:
         factory.addSteps([
@@ -327,7 +365,7 @@ def add_pyside_setup_repo(factory):
     factory.addSteps([
         ShellCommand(command=['rm', '-rf', repo_name], workdir='.', env=sandbox_path, name="Remove previous pyside"),
         Git(repourl=repo_url, branch=git_branch, workdir=repo_name, mode='incremental', method='clean', haltOnFailure=True, name="Pull " + repo_url),
-        ShellCommand(command=['python', 'setup.py', 'bdist_wheel', '--qmake=/usr/bin/qmake-qt4', '--standalone'], workdir=repo_name, env=sandbox_path, name="Wheel for " + repo_name),
+        ShellCommand(command=['python', 'setup.py', 'bdist_wheel', '--standalone'], workdir=repo_name, env=sandbox_path, name="Wheel for " + repo_name),
         ShellCommand(command=publish_pyside_wheel, workdir=repo_name + '/dist/', name="Publish pyside")
     ])
 


### PR DESCRIPTION
Buildbot knows of every codebase we pull with git for each repository,
so now both force builds and automatically triggered builds (e.g., git
polling) work.
- Related: #7256
